### PR TITLE
- feat: enable autoregister cache when roadrunner is not running, for example while building docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ RR_RPC=tcp://127.0.0.1:6001
 `fluffy_discord_road_runner.yaml`
 ```yaml
 fluffy_discord_road_runner:
+  # Optional
+  # Specify relative path from "kernel.project_dir" to your RoadRunner config file
+  # if you want to run cache:warmup without having your RoadRunner running in background,
+  # e.g. when building Docker images. Default is ".rr.yaml"
+  rr_config_path: ".rr.yaml"
+    
   # https://docs.roadrunner.dev/http/http
   http:
     # Optional

--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -13,6 +13,7 @@ class Configuration implements ConfigurationInterface
 
         $builder->getRootNode()
             ->children()
+                ->scalarNode("rr_config_path")->defaultValue(".rr.yaml")->end()
                 ->arrayNode("kv")
                     ->children()
                         ->booleanNode("auto_register")->defaultTrue()->end()

--- a/src/DependencyInjection/FluffyDiscordRoadRunnerExtension.php
+++ b/src/DependencyInjection/FluffyDiscordRoadRunnerExtension.php
@@ -8,11 +8,13 @@ use FluffyDiscord\RoadRunnerBundle\Exception\CacheAutoRegisterException;
 use FluffyDiscord\RoadRunnerBundle\Exception\InvalidRPCConfigurationException;
 use FluffyDiscord\RoadRunnerBundle\Worker\CentrifugoWorker;
 use FluffyDiscord\RoadRunnerBundle\Worker\HttpWorker;
+use Spiral\Goridge\Exception\RelayException;
 use Spiral\Goridge\RPC\RPCInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
+use Symfony\Component\Yaml\Yaml;
 
 class FluffyDiscordRoadRunnerExtension extends Extension
 {
@@ -34,17 +36,7 @@ class FluffyDiscordRoadRunnerExtension extends Extension
         }
 
         if (!isset($config["kv"]["auto_register"]) || $config["kv"]["auto_register"]) {
-            try {
-                $rpc = $container->get(RPCInterface::class);
-            } catch (InvalidRPCConfigurationException $invalidRPCConfigurationException) {
-                throw new CacheAutoRegisterException($invalidRPCConfigurationException->getMessage(), previous: $invalidRPCConfigurationException);
-            }
-
-            try {
-                $rrConfig = json_decode(base64_decode($rpc->call("rpc.Config", null)), true, 512, JSON_THROW_ON_ERROR);
-            } catch (\JsonException $jsonException) {
-                throw new CacheAutoRegisterException($jsonException->getMessage(), previous: $jsonException);
-            }
+            $rrConfig = $this->getRoadRunnerConfig($container, $config);
 
             foreach (array_keys($rrConfig["kv"] ?? []) as $name) {
                 $container
@@ -60,6 +52,37 @@ class FluffyDiscordRoadRunnerExtension extends Extension
                     ])
                 ;
             }
+        }
+    }
+
+    private function getRoadRunnerConfig(ContainerBuilder $container, array $config): array
+    {
+        try {
+            $rpc = $container->get(RPCInterface::class);
+        } catch (InvalidRPCConfigurationException $invalidRPCConfigurationException) {
+            throw new CacheAutoRegisterException($invalidRPCConfigurationException->getMessage(), previous: $invalidRPCConfigurationException);
+        } catch (RelayException $relayException) {
+            if ($config["rr_config_path"] !== null) {
+                $rrConfigPathname = $container->getParameter("kernel.project_dir") . "/" . $config["rr_config_path"];
+                if (!file_exists($rrConfigPathname)) {
+                    throw new CacheAutoRegisterException(sprintf('Specified RoadRunner config was not found: %s', $rrConfigPathname), previous: $relayException);
+                }
+
+                $yamlConfig = @file_get_contents($rrConfigPathname);
+                if ($yamlConfig === false) {
+                    throw new CacheAutoRegisterException(sprintf('Unable to read RoadRunner config, check permissions: %s', $rrConfigPathname), previous: $relayException);
+                }
+
+                return Yaml::parse($yamlConfig);
+            }
+
+            throw new CacheAutoRegisterException('Error connecting to RPC service. Is RoadRunner running? Optionally set "rr_config_path" in bundle\'s config.', previous: $relayException);
+        }
+
+        try {
+            return json_decode(base64_decode($rpc->call("rpc.Config", null)), true, 512, JSON_THROW_ON_ERROR);
+        } catch (\JsonException $jsonException) {
+            throw new CacheAutoRegisterException($jsonException->getMessage(), previous: $jsonException);
         }
     }
 }


### PR DESCRIPTION
```yaml
fluffy_discord_road_runner:
  # Optional
  # Specify relative path from "kernel.project_dir" to your RoadRunner config file
  # if you want to run cache:warmup without having your RoadRunner running in background,
  # e.g. when building Docker images. Default is ".rr.yaml"
  rr_config_path: ".rr.yaml"
```